### PR TITLE
SND-401 modify font sizes according to breakpoints

### DIFF
--- a/src/chakra-overrides/Accordion.ts
+++ b/src/chakra-overrides/Accordion.ts
@@ -1,0 +1,29 @@
+import {
+  defineStyle,
+  createMultiStyleConfigHelpers,
+} from '@chakra-ui/styled-system'
+import { accordionAnatomy as parts } from '@chakra-ui/anatomy'
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(parts.keys)
+  
+const sizes = {
+  xs: definePartsStyle(() => ({
+    panel: defineStyle({
+      fontSize: '12px',
+    })
+  })),
+  sm: definePartsStyle(() => ({
+    panel: defineStyle({
+      fontSize: '14px',
+    })
+  })),
+  md: definePartsStyle(() => ({
+    panel: defineStyle({
+      fontSize: '16px',
+    })
+  })),
+}
+
+export const Accordion = defineMultiStyleConfig({sizes})
+

--- a/src/chakra-overrides/Button.ts
+++ b/src/chakra-overrides/Button.ts
@@ -3,9 +3,15 @@ import { defineStyleConfig } from "@chakra-ui/react";
 export const Button = defineStyleConfig({
   baseStyle: {},
   sizes: {
-    lg: {},
-    md: {},
-    sm: {},
+    lg: {
+      fontSize: '18px',
+    },
+    md: {
+      fontSize: '16px',
+    },
+    sm: {
+      fontSize: '14px',
+    },
   },
   variants: {
     ghost: {},

--- a/src/chakra-overrides/List.ts
+++ b/src/chakra-overrides/List.ts
@@ -1,0 +1,29 @@
+import {
+  defineStyle,
+  createMultiStyleConfigHelpers,
+} from '@chakra-ui/styled-system'
+import { listAnatomy as parts } from '@chakra-ui/anatomy'
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(parts.keys)
+  
+const sizes = {
+  xs: definePartsStyle(() => ({
+    container: defineStyle({
+      fontSize: '12px',
+    })
+  })),
+  sm: definePartsStyle(() => ({
+    container: defineStyle({
+      fontSize: '14px',
+    })
+  })),
+  md: definePartsStyle(() => ({
+    container: defineStyle({
+      fontSize: '16px',
+    })
+  })),
+}
+
+export const List = defineMultiStyleConfig({sizes})
+

--- a/src/chakra-overrides/Text.ts
+++ b/src/chakra-overrides/Text.ts
@@ -16,6 +16,10 @@ export const Text = defineStyleConfig({
     },
   },
   sizes: {
+    xxs: {
+      fontSize: '10px',
+      lineHeight: '14px',
+    },
     xs: {
       fontSize: '12px',
       lineHeight: '16px',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import { ChakraProvider, extendTheme } from '@chakra-ui/react';
+import { ChakraProvider, extendTheme, useBreakpointValue } from '@chakra-ui/react';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -10,15 +10,25 @@ import { Text } from './chakra-overrides/Text';
 import { colors } from './chakra-overrides/colors';
 import './index.css';
 import { router } from './routes/router';
+import { List } from './chakra-overrides/List';
 
 const theme = extendTheme({
-  styles: {},
   colors,
   components: {
     Heading: Heading,
     Text: Text,
     Progress: Progress,
     Tabs: Tabs,
+    List: List,
+  },
+  breakpoints: {
+    xs: '200px', //xs
+    sm: '320px', //sm
+    md_sm: '520px', //md_sm
+    md: '768px',
+    lg: '991px',
+    xl: '1240px',
+    '2xl': '1300px',
   },
 });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,8 +23,7 @@ const theme = extendTheme({
   },
   breakpoints: {
     xs: '200px',
-    sm: '320px',
-    md_sm: '520px',
+    sm: '520px',
     md: '768px',
     lg: '991px',
     xl: '1240px',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,9 +22,9 @@ const theme = extendTheme({
     List: List,
   },
   breakpoints: {
-    xs: '200px', //xs
-    sm: '320px', //sm
-    md_sm: '520px', //md_sm
+    xs: '200px',
+    sm: '320px',
+    md_sm: '520px',
     md: '768px',
     lg: '991px',
     xl: '1240px',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import { colors } from './chakra-overrides/colors';
 import './index.css';
 import { router } from './routes/router';
 import { List } from './chakra-overrides/List';
+import { Accordion } from './chakra-overrides/Accordion';
 
 const theme = extendTheme({
   colors,
@@ -20,6 +21,7 @@ const theme = extendTheme({
     Progress: Progress,
     Tabs: Tabs,
     List: List,
+    Accordion: Accordion,
   },
   breakpoints: {
     xs: '200px',

--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -1,4 +1,7 @@
-import { Box, Flex } from '@chakra-ui/react';
+import {
+  Box,
+  Flex,
+} from '@chakra-ui/react';
 import { Outlet } from 'react-router-dom';
 import Navbar from '../ui/Navbar/Navbar';
 // import { useAuthentication } from "../utils/useAuthentication";

--- a/src/routes/usct/USCT.tsx
+++ b/src/routes/usct/USCT.tsx
@@ -1,4 +1,4 @@
-import { Flex, useBreakpointValue, Text, Heading, ListItem, List } from '@chakra-ui/react';
+import { Flex, useBreakpointValue, Text, Heading, List, Accordion } from '@chakra-ui/react';
 import { createContext, useEffect, useReducer, useRef, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import ScenarioLayout from '../../ui/ScenarioLayout/ScenarioLayout';
@@ -188,6 +188,11 @@ export default function USCT() {
   Heading.defaultProps = {
     ...Heading.defaultProps,
     size: HeadingFontsize
+  }
+
+  Accordion.defaultProps = {
+    ...Accordion.defaultProps,
+    size: TextFontsize
   }
 
   return (

--- a/src/routes/usct/USCT.tsx
+++ b/src/routes/usct/USCT.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, useBreakpointValue, Text, Heading, ListItem, List } from '@chakra-ui/react';
 import { createContext, useEffect, useReducer, useRef, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import ScenarioLayout from '../../ui/ScenarioLayout/ScenarioLayout';
@@ -146,6 +146,49 @@ export default function USCT() {
     }
     prevUserType.current = state.userType;
   }, [state.userType]);
+
+  // dyncamic default font sizes,
+  // breakpoints from main.tsx
+  const TextFontsize = useBreakpointValue(
+    {
+      xs: 'xs',
+      md_sm: 'sm',
+      md: 'md',
+      lg: 'sm',
+      xl: 'md'
+    },
+    {
+      fallback: 'md',
+    },
+  );
+
+  const HeadingFontsize = useBreakpointValue(
+    {
+      xs: 'md',
+      md_sm: 'lg',
+      md: 'lg',
+      lg: 'md',
+      xl: 'lg',
+    },
+    {
+      fallback: 'md',
+    },
+  );
+
+  Text.defaultProps = {
+    ...Text.defaultProps,
+    size: TextFontsize
+  }
+
+  List.defaultProps = {
+    ...List.defaultProps,
+    size: TextFontsize
+  }
+
+  Heading.defaultProps = {
+    ...Heading.defaultProps,
+    size: HeadingFontsize
+  }
 
   return (
     <HelpOverlay>

--- a/src/routes/usct/USCT.tsx
+++ b/src/routes/usct/USCT.tsx
@@ -152,20 +152,20 @@ export default function USCT() {
   const TextFontsize = useBreakpointValue(
     {
       xs: 'xs',
-      md_sm: 'sm',
+      sm: 'sm',
       md: 'md',
       lg: 'sm',
       xl: 'md'
     },
     {
-      fallback: 'md',
+      fallback: 'xs',
     },
   );
 
   const HeadingFontsize = useBreakpointValue(
     {
       xs: 'md',
-      md_sm: 'lg',
+      sm: 'lg',
       md: 'lg',
       lg: 'md',
       xl: 'lg',

--- a/src/ui/DIAL/DIAL.tsx
+++ b/src/ui/DIAL/DIAL.tsx
@@ -88,7 +88,7 @@ export default function DIAL() {
   const [active, setActive] = useState<null | any>();
 
   return (
-    <Box position="absolute" bottom="1rem" left="1rem">
+    <Box position="absolute" bottom="0.5rem" left="0.5rem">
       <Button
         onClick={() => { onToggle(); setOpenedBuildingBlock(null) }}
         h="72px"

--- a/src/ui/ScenarioLayout/ScenarioHeader.tsx
+++ b/src/ui/ScenarioLayout/ScenarioHeader.tsx
@@ -2,18 +2,6 @@ import { ArrowBackIcon } from '@chakra-ui/icons';
 import { Button, ChakraProvider, Flex, Image, SimpleGrid } from '@chakra-ui/react';
 import { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { extendTheme } from '@chakra-ui/react'
-
-const breakpoints = {
-  xs: '200px',
-  sm: '320px',
-  md: '768px',
-  lg: '960px',
-  xl: '1200px',
-  '2xl': '1300px',
-}
-
-const theme = extendTheme({ breakpoints })
 
 export default function ScenarioHeader({
   children,
@@ -22,7 +10,6 @@ export default function ScenarioHeader({
 }) {
 
   return (
-    <ChakraProvider theme={theme}>
     <SimpleGrid
       templateColumns={{xs: "87px 1fr", md: "87px 1fr 87px"}}
       padding={{ xs: "16px 12px", lg: "16px 64px", '2xl': '24px 64px' }}
@@ -51,6 +38,5 @@ export default function ScenarioHeader({
         {children}
       </Flex>
     </SimpleGrid>
-    </ChakraProvider>
   );
 }

--- a/src/ui/ScenarioLayout/ScenarioLayout.tsx
+++ b/src/ui/ScenarioLayout/ScenarioLayout.tsx
@@ -80,7 +80,7 @@ export default function ScenarioLayout({
           paddingBottom={{ base: '16px', md: 0 }}
         >
           <GridItem>
-            <Flex flexDirection="column">
+            <Flex flexDirection="column"  paddingTop={{ sm: '8px', md: '0' }}>
               <Flex alignItems="center" gap="16px">
                 {view === 'desktop' ? (
                   <HelpHighlightWrapper
@@ -157,11 +157,11 @@ export default function ScenarioLayout({
                   <Text
                     color={colors.theme.light}
                     fontWeight={700}
-                    fontSize={12}
+                    fontSize={{ xs: '10px', md: '12px' }}
                   >
                     {state.description.title}
                   </Text>
-                  <Text color={colors.theme.light} fontSize={12}>
+                  <Text color={colors.theme.light} fontSize={{ xs: '10px', md: '12px' }}>
                     {state.description.subtitle}
                   </Text>
                 </Box>
@@ -173,14 +173,14 @@ export default function ScenarioLayout({
                 color={colors.secondary[500]}
                 marginTop="8px"
               >
-                <Text size="sm">
+                <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }}>
                   GovStack 2023 - this is a frontend only simulation
                 </Text>
                 <Link to="https://www.govstack.global/privacy/" target="_blank">
-                  <Text size="sm">Privacy & Legal</Text>
+                  <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }}>Privacy & Legal</Text>
                 </Link>
                 <Link to="mailto:info@govstack.global">
-                  <Text size="sm">Get in touch</Text>
+                  <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }}>Get in touch</Text>
                 </Link>
               </Flex>
             </Flex>

--- a/src/ui/ScenarioLayout/ScenarioLayout.tsx
+++ b/src/ui/ScenarioLayout/ScenarioLayout.tsx
@@ -80,7 +80,7 @@ export default function ScenarioLayout({
           paddingBottom={{ base: '16px', md: 0 }}
         >
           <GridItem>
-            <Flex flexDirection="column"  paddingTop={{ sm: '8px', md: '0' }}>
+            <Flex flexDirection="column"  paddingTop={{ xs: '8px', md: '0' }}>
               <Flex alignItems="center" gap="16px">
                 {view === 'desktop' ? (
                   <HelpHighlightWrapper
@@ -173,14 +173,14 @@ export default function ScenarioLayout({
                 color={colors.secondary[500]}
                 marginTop="8px"
               >
-                <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }}>
+                <Text size={{ xs: 'xxs', sm: 'xs', md: 'sm' }}>
                   GovStack 2023 - this is a frontend only simulation
                 </Text>
                 <Link to="https://www.govstack.global/privacy/" target="_blank">
-                  <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }}>Privacy & Legal</Text>
+                  <Text size={{ xs: 'xxs', sm: 'xs', md: 'sm' }}>Privacy & Legal</Text>
                 </Link>
                 <Link to="mailto:info@govstack.global">
-                  <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }}>Get in touch</Text>
+                  <Text size={{ xs: 'xxs', sm: 'xs', md: 'sm' }}>Get in touch</Text>
                 </Link>
               </Flex>
             </Flex>

--- a/src/ui/ScenarioLayout/ScenarioView.tsx
+++ b/src/ui/ScenarioLayout/ScenarioView.tsx
@@ -66,7 +66,7 @@ export default function ScenarioView({
             textAlign="center"
             justifyContent="center"
           >
-            <Text fontSize="12px" color="#9B9B9B;">
+            <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }} color="#9B9B9B;">
               openisland-self-service-welfare.govstack
             </Text>
           </Flex>

--- a/src/ui/ScenarioLayout/ScenarioView.tsx
+++ b/src/ui/ScenarioLayout/ScenarioView.tsx
@@ -66,7 +66,7 @@ export default function ScenarioView({
             textAlign="center"
             justifyContent="center"
           >
-            <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }} color="#9B9B9B;">
+            <Text size={{ xs: 'xxs', sm: 'xs', md: 'sm' }} color="#9B9B9B;">
               openisland-self-service-welfare.govstack
             </Text>
           </Flex>

--- a/src/ui/USCTUser/USCTUser.tsx
+++ b/src/ui/USCTUser/USCTUser.tsx
@@ -90,10 +90,10 @@ export function USCTUser({ userType }: { userType: EUserType | null }) {
         <Flex gap="8px" alignItems="center" height="100%">
           <Avatar h="32px" w="32px" />
           <Box>
-            <Text fontSize="14px" fontWeight="600" lineHeight="20px">
+            <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }} fontWeight="600" lineHeight="20px">
               Civil Servant
             </Text>
-            <Text fontSize="10px" fontWeight="400" lineHeight="20px">
+            <Text fontSize={{ xs: '8px', md_sm: '10px'}} fontWeight="400" lineHeight="20px">
               Work ID: 1234567810
             </Text>
           </Box>

--- a/src/ui/USCTUser/USCTUser.tsx
+++ b/src/ui/USCTUser/USCTUser.tsx
@@ -90,10 +90,10 @@ export function USCTUser({ userType }: { userType: EUserType | null }) {
         <Flex gap="8px" alignItems="center" height="100%">
           <Avatar h="32px" w="32px" />
           <Box>
-            <Text size={{ xs: 'xxs', md_sm: 'xs', md: 'sm' }} fontWeight="600" lineHeight="20px">
+            <Text size={{ xs: 'xxs', sm: 'xs', md: 'sm' }} fontWeight="600" lineHeight="20px">
               Civil Servant
             </Text>
-            <Text fontSize={{ xs: '8px', md_sm: '10px'}} fontWeight="400" lineHeight="20px">
+            <Text fontSize={{ xs: '8px', sm: '10px'}} fontWeight="400" lineHeight="20px">
               Work ID: 1234567810
             </Text>
           </Box>


### PR DESCRIPTION
- Creates new breakpoint md_sm at 520px
- New text font sizes for use on smaller viewports
- Create dynamic text, heading, list defaultProps overrides enabling font sizes to be more in sync with artificial browser width
- Added dynamic font sizes for footer elements, navbar and top right user element "civil servant" / "applicant"